### PR TITLE
statsDateCell.colSpan now considering showExtraInfo (#20)

### DIFF
--- a/MMM-COVID19.js
+++ b/MMM-COVID19.js
@@ -279,11 +279,13 @@ Module.register("MMM-COVID19", {
           statsDateCell = document.createElement("td");
 
       statsDateCell.innerHTML = this.translate('statistic taken at ') + this.countriesStats['statistic_taken_at'] + ' (UTC)'
-      if (this.config.delta) {
-      		statsDateCell.colSpan = "7"
-    	} else {
-		statsDateCell.colSpan = "5"
-	}
+      if (this.config.delta && this.config.showExtraInfo) {
+	      statsDateCell.colSpan = "9"
+      } else if (this.config.delta || this.config.showExtraInfo) {
+	      statsDateCell.colSpan = "7" 
+      } else {
+	      statsDateCell.colSpan = "5"
+      }
       statsDateCell.className = 'last-update'
 
       statsDateRow.appendChild(statsDateCell)


### PR DESCRIPTION
@bibaldo 
The last update missed the dynamic colspan for the "statistic taken at" row at the bottom of the table.
This change observes both delta and showExtraInfo variables to set the correct colspan.