### PR TITLE
Fix active cases millions

### DIFF
--- a/MMM-COVID19.js
+++ b/MMM-COVID19.js
@@ -138,7 +138,7 @@ Module.register("MMM-COVID19", {
           newDeaths = globalStats["new_deaths"],
           totalRecovered = globalStats["total_recovered"],
           activeCases = (cases && totalRecovered)?
-              this.numberWithCommas(parseInt(cases.replace(/,/g,"")) - parseInt(totalRecovered.replace(/,/g,"")))
+              this.numberWithCommas(parseInt(cases.replace(/,/g,"")) - parseInt(totalRecovered.replace(/,/g,"")) - parseInt(deaths.replace(/,/g,"")))
               :"";
 
       worldNameCell.innerHTML = this.translate('Worldwide')

--- a/MMM-COVID19.js
+++ b/MMM-COVID19.js
@@ -138,7 +138,7 @@ Module.register("MMM-COVID19", {
           newDeaths = globalStats["new_deaths"],
           totalRecovered = globalStats["total_recovered"],
           activeCases = (cases && totalRecovered)?
-              this.numberWithCommas(parseInt(cases.replace(",","")) - parseInt(totalRecovered.replace(",","")))
+              this.numberWithCommas(parseInt(cases.replace(/,/g,"")) - parseInt(totalRecovered.replace(/,/g,"")))
               :"";
 
       worldNameCell.innerHTML = this.translate('Worldwide')


### PR DESCRIPTION
since the amount of infected grew to more than 1e6 people there are now two commas in the string containing that number. The call to "replace" just replaced the first comma in the number to nothing, therefore the parseInt call returned a bogus number.

This fixes the issue.

Also, when calculating the number of active cases the amount of deaths was not taken into account.